### PR TITLE
Add note about MQTT buffer size issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Getting Started
 
 Please consult the [M2X glossary](https://m2x.att.com/developer/documentation/glossary) if you have questions about any M2X specific terms.
 
+>Note: When connecting to M2X via an MQTT library like [hirotakaster/MQTT](https://github.com/hirotakaster/MQTT), ensure that the buffer is set to a size large enough to receive the M2X payloads. Some of these payloads, like the commands API messages, can exceed 255 bytes. See the [M2X MQTT documentation](https://m2x.att.com/developer/documentation/v2/mqtt) for more information on connecting to M2X with the MQTT protocol.
+>
+>This is not applicable when using the `m2x-particle-core` library.
+
 How to Install the library
 ==========================
 


### PR DESCRIPTION
At the request of @kristinpeterson I have added documentation to this repository for the case when a developer uses Particle with an MQTT library. There is an issue where if the buffer size is not set correctly, packets will be dropped.

Although the bug doesn't have to do with `m2x-particle-core`, we figured this is a common place people will look when developing a Particle project for M2X.